### PR TITLE
Feat: Add option to receive notifications

### DIFF
--- a/src/app/components/panel-options-ui/panel-options-ui.component.html
+++ b/src/app/components/panel-options-ui/panel-options-ui.component.html
@@ -1,4 +1,27 @@
 <div class="flex flex-row gap-2">
+
+  <div class="flex-1">
+  
+    <div class="card bg-base-100 foreground shadow-xl mt-3">
+      <div class="card-body">
+        <div class="card-title">
+          Notifications
+        </div>
+
+        <div class="form-control">
+          <label class="label cursor-pointer label-checkbox">
+            <input type="checkbox" [checked]="notificationsEnabled() === true"
+              class="checkbox checkbox-secondary" 
+              (click)="toggleNotifications()" />
+            <span class="label-text">Show notifications</span>
+          </label>
+        </div>
+
+      </div>
+
+    </div>
+  </div>
+
   <div class="flex-1 flex flex-col">
 
     <div class="card bg-base-100 foreground shadow-xl mt-3">
@@ -20,11 +43,6 @@
       </div>
 
     </div>
-  </div>
-
-  <div class="flex-1"></div>
-
-  <div class="flex-1 flex flex-col">
   </div>
 
 </div>

--- a/src/app/components/panel-options-ui/panel-options-ui.component.ts
+++ b/src/app/components/panel-options-ui/panel-options-ui.component.ts
@@ -1,7 +1,8 @@
 import { TitleCasePipe } from '@angular/common';
-import { Component, signal } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { OptionsBaseComponent } from '../panel-options/option-base-page.component';
+import { canSendNotifications } from '../../helpers';
 
 @Component({
   selector: 'app-panel-options-ui',
@@ -83,5 +84,11 @@ export class PanelOptionsUIComponent extends OptionsBaseComponent {
 
   public changeTheme(theme: string): void {
     this.setValueForOption('uiTheme', theme);
+  }
+
+  public notificationsEnabled = computed(() => canSendNotifications());
+  
+  public toggleNotifications() {
+    canSendNotifications.set(!canSendNotifications());
   }
 }

--- a/src/app/helpers/notify.ts
+++ b/src/app/helpers/notify.ts
@@ -1,7 +1,11 @@
 import { signal } from '@angular/core';
 import { Subject } from 'rxjs';
+import { localStorageSignal } from './signal';
 
-export const canSendNotifications = signal<boolean>(true);
+export const canSendNotifications = localStorageSignal<boolean>(
+  'canSendNotifications',
+  true,
+);
 
 function isPageVisible(): boolean {
   return !document.hidden;

--- a/src/app/helpers/state-options.ts
+++ b/src/app/helpers/state-options.ts
@@ -11,7 +11,7 @@ export function defaultOptions(): GameOptions {
 
     uiTheme: 'dark',
 
-    volume: 0.5,
+    volume: 0.5
   };
 }
 


### PR DESCRIPTION


# Description

Added notification toggling according to issue #12; under Options UI tab moved UI Theme selection over one column and placed notification checkbox in first column (checkbox code based on checkboxes in debug tab), updated canSendNotifications to localStorageSignal, and enabled toggling of notifications via checkbox.

Fixes #12 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ X ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
