### PR TITLE
Feature/inventory item count

### DIFF
--- a/src/app/components/panel-inventory/panel-inventory.component.html
+++ b/src/app/components/panel-inventory/panel-inventory.component.html
@@ -4,8 +4,13 @@
   <div pageactions>
     <div class="join mt-2">
       @for(type of allItemTypes; track type.type) {
-      <button class="btn btn-info join-item" [class.btn-outline]="currentItemType() !== type.type"
-        (click)="changeItemType(type.type)">{{ type.name }}</button>
+      <button
+        class="btn btn-info join-item"
+        [class.btn-outline]="currentItemType() !== type.type"
+        (click)="changeItemType(type.type)"
+      >
+        {{ type.name }} ({{ itemCounts()[type.type] }})
+      </button>
       }
     </div>
 
@@ -17,5 +22,4 @@
   <div class="flex flex-row inventory-scroller overflow-y-auto p-2">
     <app-item-grid [items]="items()"></app-item-grid>
   </div>
-
 </app-card-page>

--- a/src/app/components/panel-inventory/panel-inventory.component.ts
+++ b/src/app/components/panel-inventory/panel-inventory.component.ts
@@ -39,8 +39,8 @@ export class PanelInventoryComponent {
     };
 
     items.forEach((item: EquipmentItem) => {
-      const itemType = item.__type as EquipmentSlot;
-      if (counts[itemType] !== undefined) {
+      const itemType = item.__type;
+      if (itemType in counts) {
         counts[itemType]++;
       }
     });

--- a/src/app/components/panel-inventory/panel-inventory.component.ts
+++ b/src/app/components/panel-inventory/panel-inventory.component.ts
@@ -5,7 +5,7 @@ import {
   showInventoryMenu,
   sortedItemList,
 } from '../../helpers';
-import { EquipmentSlot } from '../../interfaces';
+import { EquipmentSlot, EquipmentItem } from '../../interfaces';
 import { CardPageComponent } from '../card-page/card-page.component';
 import { IconComponent } from '../icon/icon.component';
 import { ItemGridComponent } from '../item-grid/item-grid.component';
@@ -29,10 +29,33 @@ export class PanelInventoryComponent {
     { name: 'Weapons', type: 'weapon' },
   ];
 
+  public itemCounts = computed(() => {
+    const items = gamestate().inventory.items;
+    const counts: Record<EquipmentSlot, number> = {
+      accessory: 0,
+      armor: 0,
+      trinket: 0,
+      weapon: 0,
+    };
+
+    items.forEach((item: EquipmentItem) => {
+      const itemType = item.__type as EquipmentSlot;
+      if (counts[itemType] !== undefined) {
+        counts[itemType]++;
+      }
+    });
+
+    return counts;
+  });
+
+  public getItemCountForType(type: EquipmentSlot): number {
+    return this.itemCounts()[type];
+  }
+
   public items = computed(() =>
     sortedItemList(
       gamestate().inventory.items.filter(
-        (i) => i.__type === this.currentItemType(),
+        (i: EquipmentItem) => i.__type === this.currentItemType(),
       ),
     ),
   );


### PR DESCRIPTION
# Description

This PR adds item counts to the inventory panel headers, making it easier for users to see how many items they have in each category at a glance. The inventory buttons now display the count in parentheses next to each item type name (e.g., "Accessories (5)", "Armor (12)").

**Implementation details:**
- Added a computed signal `itemCounts` that reactively counts items by type (accessory, armor, trinket, weapon)
- Updated the inventory panel template to display counts in button headers
- Used Angular's computed signals for automatic updates when inventory changes
- Maintained existing functionality while adding the new count display

**Motivation:**
Previously, users had to click through each inventory category to see if they had items of that type. This change provides immediate visibility into inventory distribution, improving the user experience.

Fixes #31

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
