### PR TITLE
[Feature] Show delta from equipment in hero stats

### DIFF
--- a/src/app/components/marker-stat/marker-stat.component.html
+++ b/src/app/components/marker-stat/marker-stat.component.html
@@ -2,4 +2,7 @@
   <app-icon size="1.25em" [name]="icon()"></app-icon>
   <div class="min-w-[96px]">{{ stat() | titlecase }}</div>
   <div>{{ value() | number }}</div>
+  @if (displayDelta()) {
+    <div [class]="deltaColor()">{{ displayDelta() }}</div>
+  }
 </div>

--- a/src/app/components/marker-stat/marker-stat.component.ts
+++ b/src/app/components/marker-stat/marker-stat.component.ts
@@ -20,6 +20,21 @@ const icons: Record<GameStat, keyof typeof ALL_ICONS> = {
 export class MarkerStatComponent {
   public stat = input.required<GameStat>();
   public value = input.required<number>();
+  public delta = input<number>(0);
 
   public icon = computed(() => icons[this.stat()]);
+
+ public displayDelta = computed(() => {
+    const deltaValue = this.delta();
+    if (deltaValue === 0) return null;
+
+    return deltaValue > 0 ? `(+${deltaValue})` : `(${deltaValue})`;
+  });
+
+  public deltaColor = computed(() =>
+    this.delta() > 0 ? 'text-green-500' : 'text-red-500'
+  );
 }
+
+
+

--- a/src/app/components/panel-heroes-stats/panel-heroes-stats.component.html
+++ b/src/app/components/panel-heroes-stats/panel-heroes-stats.component.html
@@ -22,15 +22,15 @@
     </div>
 
     <div>
-      <app-marker-stat stat="force" [value]="heroStatTotals.force"></app-marker-stat>
+      <app-marker-stat stat="force" [value]="heroStatTotals.force" [delta]="heroStatTotals.force - hero().baseStats.force"></app-marker-stat>
     </div>
 
     <div>
-      <app-marker-stat stat="aura" [value]="heroStatTotals.aura"></app-marker-stat>
+      <app-marker-stat stat="aura" [value]="heroStatTotals.aura" [delta] = "heroStatTotals.aura - hero().baseStats.aura"></app-marker-stat>
     </div>
 
     <div>
-      <app-marker-stat stat="speed" [value]="heroStatTotals.speed"></app-marker-stat>
+      <app-marker-stat stat="speed" [value]="heroStatTotals.speed" [delta]="heroStatTotals.speed - hero().baseStats.speed"></app-marker-stat>
     </div>
   </div>
 </div>

--- a/src/app/components/panel-heroes-stats/panel-heroes-stats.component.html
+++ b/src/app/components/panel-heroes-stats/panel-heroes-stats.component.html
@@ -17,7 +17,8 @@
 
   <div class="flex flex-col gap-4">
     <div>
-      <app-marker-stat stat="health" [value]="heroStatTotals.health"></app-marker-stat>
+      <app-marker-stat stat="health" [value]="heroStatTotals.health" [delta]="heroStatTotals.health - hero().baseStats.health">
+      </app-marker-stat>
     </div>
 
     <div>


### PR DESCRIPTION
# Description

Add feature: Show delta from equipment in hero stat, hp.

## Summary of Changes

Added feature for delta to health to be visible. Green for positive, red for negative.

If your PR summary is AI-generated, it will be closed.

Fixes # (issue)

## Screenshot

![After](https://github.com/user-attachments/assets/67fd672d-3213-4934-ab02-e8f00f6c510e)
![AlsoAfter](https://github.com/user-attachments/assets/609af6be-359a-4de4-9f25-2707b5785e01)
![Before](https://github.com/user-attachments/assets/467bef05-5760-4f5c-9b5b-210a8d16b2e9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [Y] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [Y] I have performed a self-review of my own code
- [Y] I have made corresponding changes to the documentation
- [Y] My changes generate no new warnings
- [N] I have run tests (npm run test) that prove my fix is effective or that my feature works
