### PR TITLE
close all menus on esc pres

### DIFF
--- a/src/app/pages/game-play/game-play.component.ts
+++ b/src/app/pages/game-play/game-play.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, computed, HostListener } from '@angular/core';
 import { GameCameraControllerComponent } from '../../components/game-camera-controller/game-camera-controller.component';
 import { GameMapComponent } from '../../components/game-map/game-map.component';
 import { PanelCombatComponent } from '../../components/panel-combat/panel-combat.component';
@@ -6,7 +6,14 @@ import { PanelHeroesComponent } from '../../components/panel-heroes/panel-heroes
 import { PanelInventoryComponent } from '../../components/panel-inventory/panel-inventory.component';
 import { PanelLocationComponent } from '../../components/panel-location/panel-location.component';
 import { PanelOptionsComponent } from '../../components/panel-options/panel-options.component';
-import { closeAllMenus } from '../../helpers';
+import {
+  closeAllMenus,
+  showCombatMenu,
+  showHeroesMenu,
+  showInventoryMenu,
+  showLocationMenu,
+  showOptionsMenu,
+} from '../../helpers';
 
 @Component({
   selector: 'app-game-play',
@@ -23,6 +30,12 @@ import { closeAllMenus } from '../../helpers';
   styleUrl: './game-play.component.scss',
 })
 export class GamePlayComponent {
+  public showOptions = computed(() => showOptionsMenu());
+  public showHeroes = computed(() => showHeroesMenu());
+  public showCombat = computed(() => showCombatMenu());
+  public showLocation = computed(() => showLocationMenu());
+  public showInventory = computed(() => showInventoryMenu());
+
   @HostListener('document:keydown.escape', ['$event'])
   onEscapeKey(event: KeyboardEvent) {
     closeAllMenus();

--- a/src/app/pages/game-play/game-play.component.ts
+++ b/src/app/pages/game-play/game-play.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { GameCameraControllerComponent } from '../../components/game-camera-controller/game-camera-controller.component';
 import { GameMapComponent } from '../../components/game-map/game-map.component';
 import { PanelCombatComponent } from '../../components/panel-combat/panel-combat.component';
@@ -6,13 +6,7 @@ import { PanelHeroesComponent } from '../../components/panel-heroes/panel-heroes
 import { PanelInventoryComponent } from '../../components/panel-inventory/panel-inventory.component';
 import { PanelLocationComponent } from '../../components/panel-location/panel-location.component';
 import { PanelOptionsComponent } from '../../components/panel-options/panel-options.component';
-import {
-  showCombatMenu,
-  showHeroesMenu,
-  showInventoryMenu,
-  showLocationMenu,
-  showOptionsMenu,
-} from '../../helpers';
+import { closeAllMenus } from '../../helpers';
 
 @Component({
   selector: 'app-game-play',
@@ -29,9 +23,10 @@ import {
   styleUrl: './game-play.component.scss',
 })
 export class GamePlayComponent {
-  public showOptions = computed(() => showOptionsMenu());
-  public showHeroes = computed(() => showHeroesMenu());
-  public showCombat = computed(() => showCombatMenu());
-  public showLocation = computed(() => showLocationMenu());
-  public showInventory = computed(() => showInventoryMenu());
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscapeKey(event: KeyboardEvent) {
+    closeAllMenus();
+    event.preventDefault();
+    event.stopPropagation();
+  }
 }


### PR DESCRIPTION
# Description
When pressing esc close all menus

## Summary of Changes
Added a listener for escape in the game play component, if esc is pressed it uses the closeAllMenus function from the ui helper file.

Fixes #9

## Screenshot
![brave_cEUwbIVDTn](https://github.com/user-attachments/assets/7d5af5f4-faa9-48b7-b773-157de33a6a1f)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
