### PR TITLE
fix overflow on settings page

### DIFF
--- a/src/app/pages/game-setup-world/game-setup-world.component.html
+++ b/src/app/pages/game-setup-world/game-setup-world.component.html
@@ -59,7 +59,7 @@
             <label
               [for]="'worldSize-' + $index"
               class="btn btn-block btn-secondary"
-              [class.btn-outline]="selectedWorldSize()?.id !== config.id"
+              [class.btn-outline]="selectedWorldSize().id !== config.id"
               appAnalyticsClick="Setup:World:{{ config.name }}"
               appSfx="ui-click"
               [sfxOffset]="$index"

--- a/src/app/pages/game-setup-world/game-setup-world.component.scss
+++ b/src/app/pages/game-setup-world/game-setup-world.component.scss
@@ -1,3 +1,3 @@
 :host {
-  @apply block h-full;
+  @apply block;
 }

--- a/src/app/pages/setup/setup.component.html
+++ b/src/app/pages/setup/setup.component.html
@@ -1,5 +1,4 @@
-<app-navbar></app-navbar>
-
-<div class="page-container">
+<app-navbar class="block flex-none"></app-navbar>
+<div class="flex-1 block overflow-y-auto">
   <router-outlet></router-outlet>
 </div>

--- a/src/app/pages/setup/setup.component.scss
+++ b/src/app/pages/setup/setup.component.scss
@@ -1,0 +1,3 @@
+:host {
+  @apply flex flex-col h-dvh;
+}


### PR DESCRIPTION
# Description

Fix overflow on setup page

## Summary of Changes

Allow for better scrolling on the setup page so it does not cutoff data

Fixes # (issue)

## Screenshot

https://github.com/user-attachments/assets/c0f24efd-4a11-4d88-b2a0-dcdcbdd8b578

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
