### PR TITLE
Fixed/Added - [Feature] Zoom out on canvas

### DIFF
--- a/src/app/components/game-map-pixi/game-map-pixi.component.ts
+++ b/src/app/components/game-map-pixi/game-map-pixi.component.ts
@@ -139,6 +139,28 @@ export class GameMapPixiComponent implements OnInit, OnDestroy {
     canvas.addEventListener('wheel', (event) => this.onWheel(event));
   }
 
+  private clampMapPosition() {
+    if (!this.mapContainer || !this.app) return;
+    const canvas = this.app.view as HTMLCanvasElement;
+    const viewWidth = canvas.width;
+    const viewHeight = canvas.height;
+    const mapWidth = this.mapContainer.width * this.zoomLevel;
+    const mapHeight = this.mapContainer.height * this.zoomLevel;
+
+    // Calculate min/max positions so the map stays within the viewport
+    const minX = Math.min(0, viewWidth - mapWidth);
+    const minY = Math.min(0, viewHeight - mapHeight);
+    const maxX = 0;
+    const maxY = 0;
+
+    this.mapContainer.position.x = Math.max(minX, Math.min(maxX, this.mapContainer.position.x));
+    this.mapContainer.position.y = Math.max(minY, Math.min(maxY, this.mapContainer.position.y));
+    if (this.playerIndicatorContainer) {
+      this.playerIndicatorContainer.position.x = this.mapContainer.position.x;
+      this.playerIndicatorContainer.position.y = this.mapContainer.position.y;
+    }
+  }
+
   private onWheel(event: WheelEvent) {
     if (!this.mapContainer || !this.app) return;
     event.preventDefault();
@@ -174,6 +196,9 @@ export class GameMapPixiComponent implements OnInit, OnDestroy {
       this.mapContainer.position.x,
       this.mapContainer.position.y,
     );
+
+    // Clamp the map position so it doesn't go out of bounds
+    this.clampMapPosition();
   }
 
   private async loadTextures() {


### PR DESCRIPTION
# Description

## Summary of Changes

Added mouse wheel zoom support to the game map.  
Zooming is centered on the mouse cursor for improved usability.  
Zoom is clamped between 0.5x (zoomed out) and 1.0x (default, 64x64 tiles).  
The zoom level is smoothly updated as the user scrolls the mouse wheel.

Fixes # ([Feature] Zoom out on canvas)

## Screenshot

<img width="1465" alt="Screenshot 2025-06-15 at 10 32 32 AM" src="https://github.com/user-attachments/assets/931cfe61-8315-416b-b711-c4f123a292ed" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test) that prove my fix is effective or that my feature works
