### PR TITLE
[Feature] Limit panel width to 1500px and add responsive padding (#64)

### DIFF
--- a/src/app/components/card-page/card-page.component.html
+++ b/src/app/components/card-page/card-page.component.html
@@ -1,4 +1,6 @@
-<div class="card bg-base-100 shadow-xl m-4 page-card" [style.height]="height()">
+<div class="card bg-base-100 shadow-xl m-4 page-card" 
+     [style.height]="height()" 
+     [style.max-width.px]="1500">
   <div class="card-body h-full">
     <h1 class="card-title justify-between">
       <ng-content select="[header]"></ng-content>

--- a/src/app/components/card-page/card-page.component.html
+++ b/src/app/components/card-page/card-page.component.html
@@ -1,17 +1,21 @@
-<div class="card bg-base-100 shadow-xl m-4 page-card" 
-     [style.height]="height()" 
-     [style.max-width.px]="1500">
-  <div class="card-body h-full">
-    <h1 class="card-title justify-between">
-      <ng-content select="[header]"></ng-content>
+<div class="w-full px-2 sm:px-3 md:px-5 lg:px-6 xl:px-8">
+  <div class="card bg-base-100 shadow-xl my-4 page-card mx-auto"
+       [style.height]="height()"
+       [style.max-width.px]="1500">
 
-      <div>
-        <ng-content select="[pageactions]"></ng-content>
+    <div class="card-body h-full">
+      <h1 class="card-title justify-between">
+        <ng-content select="[header]"></ng-content>
+
+        <div>
+          <ng-content select="[pageactions]"></ng-content>
+        </div>
+      </h1>
+
+      <div class="card-content h-full mt-3">
+        <ng-content></ng-content>
       </div>
-    </h1>
-
-    <div class="card-content h-full mt-3">
-      <ng-content></ng-content>
     </div>
+
   </div>
 </div>


### PR DESCRIPTION
PR Description

What this PR does:
Improves the layout responsiveness by adjusting the horizontal spacing around the main panel to prevent it from touching the edges of the screen, especially on smaller viewports.


✅ Changes Made:

    Wrapped the card component in a container with responsive horizontal padding.

    Used minimal Tailwind padding classes (px-2 → xl:px-8) to maintain a subtle gap on both sides of the screen.

    Ensured the card remains centered (mx-auto) and constrained to a maximum width of 1500px.

    Improves overall visual balance and readability without sacrificing screen real estate.

At 1500px width
![1500](https://github.com/user-attachments/assets/7518d5b0-e12f-4a4c-b040-aa5a8403d501)

At 1800px width
![1800](https://github.com/user-attachments/assets/a8c7f2a0-4b87-41f0-92f8-d9ba43acefa9)
