### PR TITLE
Chore: clean up localStorage by moving states into optionsState

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -9,8 +9,10 @@ import {
   closeAllMenus,
   focusCameraOnPlayer,
   gamestate,
+  getOption,
   globalStatusText,
   isGameloopPaused,
+  setOption,
   showCombatMenu,
   showCurrencyList,
   showHeroesMenu,
@@ -41,7 +43,7 @@ export class NavbarComponent {
   public meta = inject(MetaService);
   public router = inject(Router);
 
-  public isPaused = computed(() => isGameloopPaused());
+  public isPaused = computed(() => getOption('gameloopPaused'));
   public currentStatus = computed(() => globalStatusText());
 
   public shouldShowCurrencyList = computed(() => showCurrencyList());
@@ -146,6 +148,6 @@ export class NavbarComponent {
   }
 
   public togglePause() {
-    isGameloopPaused.set(!isGameloopPaused());
+    setOption('gameloopPaused', !this.isPaused())
   }
 }

--- a/src/app/components/panel-combat/panel-combat.component.html
+++ b/src/app/components/panel-combat/panel-combat.component.html
@@ -15,8 +15,8 @@
         role="tab"
         class="tab"
         [class.tab-active]="currentTab === tab.link"
-        (click)="activeTab.set(tab.link)"
-        (keydown)="activeTab.set(tab.link)"
+        (click)="changeActiveTab(tab.link)"
+        (keydown)="changeActiveTab(tab.link)"
       >
         {{ tab.name }}
       </button>

--- a/src/app/components/panel-combat/panel-combat.component.ts
+++ b/src/app/components/panel-combat/panel-combat.component.ts
@@ -1,10 +1,13 @@
-import { Component } from '@angular/core';
-import { localStorageSignal, showCombatMenu } from '../../helpers';
+import { Component, computed } from '@angular/core';
+import { showCombatMenu } from '../../helpers';
 import { CardPageComponent } from '../card-page/card-page.component';
 import { IconComponent } from '../icon/icon.component';
 import { PanelCombatClaimsComponent } from '../panel-combat-claims/panel-combat-claims.component';
 import { PanelCombatCombatlogComponent } from '../panel-combat-combatlog/panel-combat-combatlog.component';
 import { PanelCombatPreferencesComponent } from '../panel-combat-preferences/panel-combat-preferences.component';
+import { options } from '../../helpers';
+import { OptionsBaseComponent } from '../panel-options/option-base-page.component';
+import { CombatTab, CombatTabLink } from '../../interfaces';
 
 @Component({
   selector: 'app-panel-combat',
@@ -18,10 +21,14 @@ import { PanelCombatPreferencesComponent } from '../panel-combat-preferences/pan
   templateUrl: './panel-combat.component.html',
   styleUrl: './panel-combat.component.css',
 })
-export class PanelCombatComponent {
-  public activeTab = localStorageSignal<string>('combatTab', 'preferences');
+export class PanelCombatComponent extends OptionsBaseComponent {
+  public activeTab = computed(() => options()['combatTab']);
 
-  public readonly tabs = [
+  public changeActiveTab(tab: CombatTab): void {
+    this.setValueForOption('combatTab', tab);  
+  } 
+  
+  public readonly tabs: CombatTabLink[] = [
     {
       name: 'Preferences',
       link: 'preferences',

--- a/src/app/components/panel-inventory/panel-inventory.component.ts
+++ b/src/app/components/panel-inventory/panel-inventory.component.ts
@@ -1,17 +1,16 @@
 import { Component, computed } from '@angular/core';
 import {
   gamestate,
-  localStorageSignal,
+  getOption,
+  setOption,
   showInventoryMenu,
   sortedRarityList,
 } from '../../helpers';
-import { EquipmentItem, EquipmentSkill, EquipmentSlot } from '../../interfaces';
+import { EquipmentItem, EquipmentSkill, EquipmentSlot, InventorySlotType } from '../../interfaces';
 import { CardPageComponent } from '../card-page/card-page.component';
 import { IconComponent } from '../icon/icon.component';
 import { InventoryGridItemComponent } from '../inventory-grid-item/inventory-grid-item.component';
 import { InventoryGridSkillComponent } from '../inventory-grid-skill/inventory-grid-skill.component';
-
-type InventorySlotType = EquipmentSlot | 'skill';
 
 @Component({
   selector: 'app-panel-inventory',
@@ -25,10 +24,7 @@ type InventorySlotType = EquipmentSlot | 'skill';
   styleUrl: './panel-inventory.component.scss',
 })
 export class PanelInventoryComponent {
-  public currentItemType = localStorageSignal<InventorySlotType>(
-    'inventoryFilter',
-    'accessory',
-  );
+  public currentItemType = computed(() => getOption('inventoryFilter'));
 
   public readonly allItemTypes: Array<{
     name: string;
@@ -84,6 +80,6 @@ export class PanelInventoryComponent {
   }
 
   changeItemType(type: InventorySlotType) {
-    this.currentItemType.set(type);
+    setOption('inventoryFilter', type);
   }
 }

--- a/src/app/components/panel-options-ui/panel-options-ui.component.ts
+++ b/src/app/components/panel-options-ui/panel-options-ui.component.ts
@@ -2,14 +2,12 @@ import { TitleCasePipe } from '@angular/common';
 import { Component, computed, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
-  canSendNotifications,
-  enabledCategories,
   getOption,
   setOption,
-  ToggleableCategory,
 } from '../../helpers';
 import { GameOptions } from '../../interfaces';
 import { OptionsBaseComponent } from '../panel-options/option-base-page.component';
+import { ToggleableCategory } from '../../interfaces';
 
 @Component({
   selector: 'app-panel-options-ui',
@@ -22,8 +20,9 @@ export class PanelOptionsUIComponent extends OptionsBaseComponent {
     this.currentValueForOption('uiTheme') as string,
   );
 
-  public notificationsEnabled = computed(() => canSendNotifications());
-  public notificationCategoriesEnabled = computed(() => enabledCategories());
+  public notificationsEnabled = computed(() => this.currentValueForOption('canSendNotifications'));
+
+  public notificationCategoriesEnabled = computed(() => this.currentValueForOption('enabledNotificationCategories') as ToggleableCategory[]);
 
   public readonly themes = [
     { name: 'acid', type: 'light' },
@@ -106,18 +105,19 @@ export class PanelOptionsUIComponent extends OptionsBaseComponent {
   ) {
     setOption(option, value);
   }
-
+  
   public toggleNotifications() {
-    canSendNotifications.set(!canSendNotifications());
+    this.setValueForOption('canSendNotifications', !this.currentValueForOption('canSendNotifications'));
   }
 
   public toggleNotificationCategories(category: ToggleableCategory) {
-    if (enabledCategories().includes(category)) {
-      enabledCategories.set(
-        enabledCategories().filter((cat) => cat !== category),
-      );
+    if (this.notificationCategoriesEnabled().includes(category)) {
+      const newEnabledCategories = this.notificationCategoriesEnabled().filter((cat: ToggleableCategory) => cat !== category);
+      this.setValueForOption('enabledNotificationCategories', newEnabledCategories);
+      
       return;
     }
-    enabledCategories.set([...enabledCategories(), category]);
+
+    this.setValueForOption('enabledNotificationCategories', [...this.notificationCategoriesEnabled(), category]);
   }
 }

--- a/src/app/components/panel-options/panel-options.component.html
+++ b/src/app/components/panel-options/panel-options.component.html
@@ -17,8 +17,8 @@
         role="tab"
         class="tab"
         [class.tab-active]="currentTab === tab.link"
-        (click)="activeTab.set(tab.link)"
-        (keydown)="activeTab.set(tab.link)"
+        (click)="changeActiveTab(tab.link)"
+        (keydown)="changeActiveTab(tab.link)"
         [appAnalyticsClick]="'Options:Navigate:' + tab.name"
         [class.hidden]="!tab.showIf()"
       >

--- a/src/app/components/panel-options/panel-options.component.ts
+++ b/src/app/components/panel-options/panel-options.component.ts
@@ -1,12 +1,14 @@
 import { Component, computed } from '@angular/core';
 import { AnalyticsClickDirective } from '../../directives/analytics-click.directive';
-import { localStorageSignal, options, showOptionsMenu } from '../../helpers';
+import { options, showOptionsMenu } from '../../helpers';
 import { CardPageComponent } from '../card-page/card-page.component';
 import { ConnectButtonsComponent } from '../connect-buttons/connect-buttons.component';
 import { IconComponent } from '../icon/icon.component';
 import { PanelOptionsDebugComponent } from '../panel-options-debug/panel-options-debug.component';
 import { PanelOptionsSavefileComponent } from '../panel-options-savefile/panel-options-savefile.component';
 import { PanelOptionsUIComponent } from '../panel-options-ui/panel-options-ui.component';
+import { OptionsBaseComponent } from './option-base-page.component';
+import { OptionsTab, OptionsTabLink } from '../../interfaces';
 
 @Component({
   selector: 'app-panel-options',
@@ -22,10 +24,14 @@ import { PanelOptionsUIComponent } from '../panel-options-ui/panel-options-ui.co
   templateUrl: './panel-options.component.html',
   styleUrl: './panel-options.component.css',
 })
-export class PanelOptionsComponent {
-  public activeTab = localStorageSignal<string>('optionsTab', 'ui');
+export class PanelOptionsComponent extends OptionsBaseComponent {
+  public activeTab = computed(() => options()['optionsTab']);
 
-  public readonly tabs = [
+  public changeActiveTab(tab: OptionsTab): void {
+    this.setValueForOption('optionsTab', tab);
+  }
+
+  public readonly tabs: OptionsTabLink[] = [
     {
       name: 'UI',
       link: 'ui',

--- a/src/app/components/panel-town/panel-town.component.html
+++ b/src/app/components/panel-town/panel-town.component.html
@@ -15,8 +15,8 @@
         role="tab"
         class="tab"
         [class.tab-active]="currentTab === tab.link"
-        (click)="activeTab.set(tab.link)"
-        (keydown)="activeTab.set(tab.link)"
+        (click)="changeActiveTab(tab.link)"
+        (keydown)="changeActiveTab(tab.link)"
         [appAnalyticsClick]="'Town:Navigate:' + tab.name"
         [class.hidden]="!tab.showIf()"
       >

--- a/src/app/components/panel-town/panel-town.component.ts
+++ b/src/app/components/panel-town/panel-town.component.ts
@@ -2,7 +2,9 @@ import { Component, computed, Signal } from '@angular/core';
 import { AnalyticsClickDirective } from '../../directives/analytics-click.directive';
 import {
   getBuildingLevel,
+  getOption,
   localStorageSignal,
+  setOption,
   showTownMenu,
 } from '../../helpers';
 import { TownBuilding } from '../../interfaces';
@@ -28,8 +30,12 @@ import { PanelTownMerchantComponent } from '../panel-town-merchant/panel-town-me
   styleUrl: './panel-town.component.scss',
 })
 export class PanelTownComponent {
-  public activeTab = localStorageSignal<TownBuilding>('townTab', 'Market');
+  // public activeTab = localStorageSignal<TownBuilding>('townTab', 'Market');
+  public activeTab = computed(() => getOption('townTab'));
 
+  public changeActiveTab(building: TownBuilding) {
+    setOption('townTab', building);
+  }
   public readonly tabs: Array<{
     name: string;
     link: TownBuilding;

--- a/src/app/helpers/gameloop.ts
+++ b/src/app/helpers/gameloop.ts
@@ -11,8 +11,9 @@ import { isSetup } from './setup';
 import { localStorageSignal } from './signal';
 import { isGameStateReady, updateGamestate } from './state-game';
 import { getOption } from './state-options';
+import { computed } from '@angular/core';
 
-export const isGameloopPaused = localStorageSignal<boolean>('paused', false);
+export const isGameloopPaused = computed(() => getOption('gameloopPaused'));
 
 export function doGameloop(numTicks: number): void {
   if (!isSetup()) return;

--- a/src/app/helpers/notify.ts
+++ b/src/app/helpers/notify.ts
@@ -1,26 +1,18 @@
 import { Subject } from 'rxjs';
-import { localStorageSignal } from './signal';
-
-export const canSendNotifications = localStorageSignal<boolean>(
-  'canSendNotifications',
-  true,
-);
+import { options } from './state-options';
+import { NotificationCategory, ToggleableCategory } from '../interfaces';
 
 function isPageVisible(): boolean {
   return !document.hidden;
 }
 
-type NotificationCategory = 'Error' | 'Success' | 'Travel' | 'LocationClaim';
-
-export type ToggleableCategory = Exclude<
-  NotificationCategory,
-  'Error' | 'Success'
->;
-
-export const enabledCategories = localStorageSignal<ToggleableCategory[]>(
-  'enabledNotificationCategories',
-  ['Travel', 'LocationClaim'],
-);
+// export const enabledCategories = localStorageSignal<ToggleableCategory[]>(
+//   'enabledNotificationCategories',
+//   [
+//     'Travel', 
+//     'LocationClaim'
+//   ]
+// );
 
 const notification = new Subject<{
   message: string;
@@ -31,11 +23,11 @@ export const notification$ = notification.asObservable();
 
 export function notify(message: string, category: NotificationCategory): void {
   if (
-    !isPageVisible() ||
-    !canSendNotifications() ||
-    !enabledCategories().includes(category as ToggleableCategory)
-  )
-    return;
+    !isPageVisible() || 
+    !options()['canSendNotifications'] || 
+    !options()['enabledNotificationCategories'].includes(category as ToggleableCategory)
+  ) return;
+
   notification.next({ message, type: 'show', category });
 }
 

--- a/src/app/helpers/state-options.ts
+++ b/src/app/helpers/state-options.ts
@@ -15,6 +15,13 @@ export function defaultOptions(): GameOptions {
     uiTheme: 'dark',
 
     volume: 0.5,
+    gameloopPaused: false,
+    canSendNotifications: true,
+    enabledNotificationCategories: ['Travel', 'LocationClaim'],
+    combatTab: 'preferences',
+    optionsTab: 'ui',
+    townTab: 'Market',
+    inventoryFilter: 'accessory',
   };
 }
 

--- a/src/app/interfaces/equipment.ts
+++ b/src/app/interfaces/equipment.ts
@@ -21,3 +21,5 @@ export type EquipmentItemDefinition = DroppableEquippable &
 export type EquipmentItem = EquipmentItemDefinition & {
   mods: Partial<EquipmentModifiable>;
 };
+
+export type InventorySlotType = EquipmentSlot | 'skill';

--- a/src/app/interfaces/state-options.ts
+++ b/src/app/interfaces/state-options.ts
@@ -1,3 +1,7 @@
+import { Signal } from "@angular/core";
+import { InventorySlotType } from "./equipment";
+import { TownBuilding } from "./town";
+
 export type GameOption =
   | 'showDebug'
   | 'debugConsoleLogStateUpdates'
@@ -5,7 +9,32 @@ export type GameOption =
   | 'debugGameloopTimerUpdates'
   | 'audioPlay';
 
+export type NotificationCategory = 'Error' | 'Success' | 'Travel' | 'LocationClaim';
+  
+export type ToggleableCategory = Exclude<NotificationCategory, 'Error' | 'Success'>;
+
+export type CombatTab = 'preferences' | 'combatlog' | 'claims';
+export type OptionsTab = 'ui' | 'savefile' | 'debug';
+
+export interface CombatTabLink {
+  name: 'Preferences' | 'Combat Log' | 'Claims';
+  link: CombatTab
+}
+
+export interface OptionsTabLink {
+  name: 'UI' | 'Savefile' | 'Debug';
+  link: OptionsTab;
+  showIf: Signal<boolean>;
+}
+  
 export type GameOptions = Record<GameOption, boolean> & {
   uiTheme: string;
   volume: number;
+  gameloopPaused: boolean;
+  canSendNotifications: boolean;
+  enabledNotificationCategories: ToggleableCategory[];
+  combatTab: CombatTab;
+  optionsTab: OptionsTab;
+  townTab: TownBuilding;
+  inventoryFilter: InventorySlotType;
 };

--- a/src/app/pages/game-play/game-play.component.ts
+++ b/src/app/pages/game-play/game-play.component.ts
@@ -8,8 +8,10 @@ import { PanelOptionsComponent } from '../../components/panel-options/panel-opti
 import { PanelTownComponent } from '../../components/panel-town/panel-town.component';
 
 import {
-  isGameloopPaused,
   closeAllMenus,
+  getOption,
+  isGameloopPaused,
+  setOption,
   showCombatMenu,
   showHeroesMenu,
   showInventoryMenu,
@@ -39,6 +41,7 @@ export class GamePlayComponent {
   public showLocation = computed(() => showLocationMenu());
   public showInventory = computed(() => showInventoryMenu());
   public showTown = computed(() => showTownMenu());
+  private isGameloopPaused = computed(() => getOption('gameloopPaused'));
 
   @HostListener('document:keydown.escape', ['$event'])
   onEscapeKey(event: KeyboardEvent) {
@@ -49,7 +52,8 @@ export class GamePlayComponent {
 
 @HostListener('document:keydown.space', ['$event'])
 onSpaceKey(event: KeyboardEvent) {
-  isGameloopPaused.set(!isGameloopPaused());
+  // isGameloopPaused.set(!isGameloopPaused());
+  setOption('gameloopPaused', !this.isGameloopPaused());
   event.preventDefault();
   event.stopPropagation();
 }


### PR DESCRIPTION
# Description

Refactored canSendNotifications, combatTab, optionsTab, townTab, enabledNotificationCategories, isPaused, and inventoryFilter into optionsState. Refactor affected code such as creating types and moving types to type files.

## Summary of Changes

I moved all the states into optionsState as requested, as well as any that seemed logical (like townTab, isPaused, and inventoryFilter).

Fixes #24 

## Screenshot

https://github.com/user-attachments/assets/c2a3d18c-8475-4840-aef5-78cefeddfac0

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
