### PR TITLE
Combat log health color coding for better visual clarity #78

### DIFF
--- a/src/app/components/panel-combat-combatlog/panel-combat-combatlog.component.ts
+++ b/src/app/components/panel-combat-combatlog/panel-combat-combatlog.component.ts
@@ -3,6 +3,7 @@ import { Component, computed } from '@angular/core';
 import { marked } from 'marked';
 import { combatLog, rarityItemColor } from '../../helpers';
 import { DropRarity } from '../../interfaces/droppable';
+import { getHealthColor } from '../../helpers/combat-log';
 
 @Component({
   selector: 'app-panel-combat-combatlog',
@@ -13,6 +14,7 @@ import { DropRarity } from '../../interfaces/droppable';
 export class PanelCombatCombatlogComponent {
   private createCustomRenderer() {
     const renderer = new marked.Renderer();
+    const regex: RegExp = /\((\d+)\/(\d+) HP remaining\)/;
 
     renderer.codespan = ({ text }: { text: string }) => {
       if (text.startsWith('rarity:')) {
@@ -21,6 +23,13 @@ export class PanelCombatCombatlogComponent {
         return `<span class="text-${colorClass} font-bold">${itemName}</span>`;
       }
       return `<code>${text}</code>`;
+    };
+    renderer.text = ({ text }: { text: string }) => {
+      return text.replace(regex, (match, currentHp, maxHp) => {
+        const current = parseInt(currentHp);
+        const max = parseInt(maxHp);
+        return `<span class="text-${getHealthColor(current, max)}">${match}</span>`;
+      });
     };
 
     return renderer;

--- a/src/app/helpers/combat-log.ts
+++ b/src/app/helpers/combat-log.ts
@@ -15,3 +15,20 @@ export function logCombatMessage(combat: Combat, message: string): void {
 
   combatLog.update((logs) => [newLog, ...logs].slice(0, 500));
 }
+
+export function getHealthColor(health: number, totalHealth: number): string {
+  let healthColor: string;
+
+  const healthPercentage = Math.round((100 * health) / totalHealth);
+
+  if (healthPercentage >= 75) {
+    healthColor = 'green-400';
+  } else if (healthPercentage < 75 && healthPercentage > 25) {
+    healthColor = 'yellow-400';
+  } else {
+    healthColor = 'rose-400';
+  }
+
+  console.log(healthColor);
+  return healthColor;
+}


### PR DESCRIPTION

![#78 Git Image](https://github.com/user-attachments/assets/907329a4-2868-42b6-b98e-5d77524ac49e)
- Add getHealthColor helper function with traffic light color scheme: • High health (75-100%): green-400 • Medium health (25-74%): yellow-400 • Low health (0-24%): rose-400
- Implement text renderer in combat log component to apply health colors
- Parse HP values from combat messages using regex pattern matching
- Maintain separation between business logic and presentation layers

# Description

## Summary of Changes

If your PR summary is AI-generated, it will be closed.

Fixes # (issue)

## Screenshot

Upload a screenshot if applicable, otherwise remove this section.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
