### PR TITLE
#78 combat log health color coding for better visual clarity

### DIFF
--- a/src/app/components/panel-combat-combatlog/panel-combat-combatlog.component.ts
+++ b/src/app/components/panel-combat-combatlog/panel-combat-combatlog.component.ts
@@ -28,7 +28,8 @@ export class PanelCombatCombatlogComponent {
       return text.replace(regex, (match, currentHp, maxHp) => {
         const current = parseInt(currentHp);
         const max = parseInt(maxHp);
-        return `<span class="text-${getHealthColor(current, max)}">${match}</span>`;
+        const colorClass = getHealthColor(current, max);
+        return `<span class="${colorClass}">${match}</span>`;
       });
     };
 

--- a/src/app/components/panel-combat-combatlog/panel-combat-combatlog.component.ts
+++ b/src/app/components/panel-combat-combatlog/panel-combat-combatlog.component.ts
@@ -3,6 +3,7 @@ import { Component, computed } from '@angular/core';
 import { marked } from 'marked';
 import { combatLog, rarityItemColor } from '../../helpers';
 import { DropRarity } from '../../interfaces/droppable';
+import { getHealthColor } from '../../helpers/combat-log';
 
 @Component({
   selector: 'app-panel-combat-combatlog',
@@ -13,6 +14,7 @@ import { DropRarity } from '../../interfaces/droppable';
 export class PanelCombatCombatlogComponent {
   private createCustomRenderer() {
     const renderer = new marked.Renderer();
+    const regex: RegExp = /\((\d+)\/(\d+) HP remaining\)/;
 
     renderer.codespan = ({ text }: { text: string }) => {
       if (text.startsWith('rarity:')) {
@@ -21,6 +23,13 @@ export class PanelCombatCombatlogComponent {
         return `<span class="text-${colorClass} font-bold">${itemName}</span>`;
       }
       return `<code>${text}</code>`;
+    };
+    renderer.text = ({ text }: { text: string }) => {
+      return text.replace(regex, (match, currentHp, maxHp) => {
+        const current = parseInt(currentHp);
+        const max = parseInt(maxHp);
+        return `<span class="text-${getHealthColor(current, max)}">${match}</span>`;
+      });
     };
 
     return renderer;

--- a/src/app/helpers/combat-log.ts
+++ b/src/app/helpers/combat-log.ts
@@ -17,18 +17,13 @@ export function logCombatMessage(combat: Combat, message: string): void {
 }
 
 export function getHealthColor(health: number, totalHealth: number): string {
-  let healthColor: string;
-
   const healthPercentage = Math.round((100 * health) / totalHealth);
 
   if (healthPercentage >= 75) {
-    healthColor = 'green-400';
-  } else if (healthPercentage < 75 && healthPercentage > 25) {
-    healthColor = 'yellow-400';
-  } else {
-    healthColor = 'rose-400';
+    return 'text-green-400';
+  } else if (healthPercentage > 25) {
+    return 'text-yellow-400';
   }
 
-  console.log(healthColor);
-  return healthColor;
+  return 'text-rose-400';
 }

--- a/src/app/helpers/combat-log.ts
+++ b/src/app/helpers/combat-log.ts
@@ -15,3 +15,20 @@ export function logCombatMessage(combat: Combat, message: string): void {
 
   combatLog.update((logs) => [newLog, ...logs].slice(0, 500));
 }
+
+export function getHealthColor(health: number, totalHealth: number): string {
+  let healthColor: string;
+
+  const healthPercentage = Math.round((100 * health) / totalHealth);
+
+  if (healthPercentage >= 75) {
+    healthColor = 'green-400';
+  } else if (healthPercentage < 75 && healthPercentage > 25) {
+    healthColor = 'yellow-400';
+  } else {
+    healthColor = 'rose-400';
+  }
+
+  console.log(healthColor);
+  return healthColor;
+}


### PR DESCRIPTION
# Description

feat: Add health color coding to combat log

- Add getHealthColor helper function with traffic light color scheme:
  • High health (75-100%): text-green-400
  • Medium health (25-74%): text-yellow-400  
  • Low health (0-24%): text-red-400
- Implement text renderer in combat log component to apply health colors
- Parse HP values from combat messages using regex pattern matching
- Use complete Tailwind class names to ensure proper CSS generation
- Maintain separation between business logic and presentation layers

## Summary of Changes

If your PR summary is AI-generated, it will be closed.

Fixes #78

## Screenshot

Upload a screenshot if applicable, otherwise remove this section.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
