### PR TITLE
reset combat log on new game

### DIFF
--- a/src/app/helpers/combat-log.ts
+++ b/src/app/helpers/combat-log.ts
@@ -16,6 +16,10 @@ export function logCombatMessage(combat: Combat, message: string): void {
   combatLog.update((logs) => [newLog, ...logs].slice(0, 500));
 }
 
+export function resetCombatLog(): void {
+  combatLog.set([]);
+}
+
 export function getHealthColor(health: number, totalHealth: number): string {
   const healthPercentage = Math.round((100 * health) / totalHealth);
 

--- a/src/app/helpers/state-game.ts
+++ b/src/app/helpers/state-game.ts
@@ -11,6 +11,7 @@ import {
 } from '../interfaces';
 import { uuid } from './rng';
 import { localStorageSignal } from './signal';
+import { resetCombatLog } from './combat-log';
 
 export function blankHero(props: Partial<Hero> = {}): Hero {
   return {
@@ -172,6 +173,7 @@ export const isGameStateReady = signal<boolean>(false);
 
 export function resetGameState(): void {
   _gamestate.set(blankGameState());
+  resetCombatLog();
 }
 
 export function setGameState(state: GameState): void {


### PR DESCRIPTION
# Description
An issue was found where the combat log was not resetting. The chosen solution was to create a simple resetCombatLog function and call it in the resetGame helper.

## Summary of Changes
Make a resetCombatLog function, and call it in the resetGame helper when user goes through flow for starting new game.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
