### PR TITLE
[Feature] Migrate hotkey uses to ngneat/hotkeys #73

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@ng-icons/tabler-icons": "^29.8.0",
         "@ng-select/ng-select": "^14.9.0",
         "@ngneat/helipopper": "^9.2.1",
+        "@ngneat/hotkeys": "^4.1.0",
         "@ngneat/overview": "^6.1.2",
         "@ngxpert/hot-toast": "^3.0.2",
         "@pixi/graphics": "^7.4.3",
@@ -3315,6 +3316,15 @@
       },
       "peerDependencies": {
         "@angular/core": ">=17.0.0"
+      }
+    },
+    "node_modules/@ngneat/hotkeys": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/hotkeys/-/hotkeys-4.1.0.tgz",
+      "integrity": "sha512-bqtmK0wMGQOFtNnxmklnbhVbiUoOIp5rXY4UeWGRoMgf7RGvW6dO5moZSPzenJwp8pgi2EmSyo+xpQ8R512hIw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
       }
     },
     "node_modules/@ngneat/overview": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@ng-icons/tabler-icons": "^29.8.0",
     "@ng-select/ng-select": "^14.9.0",
     "@ngneat/helipopper": "^9.2.1",
+    "@ngneat/hotkeys": "^4.1.0",
     "@ngneat/overview": "^6.1.2",
     "@ngxpert/hot-toast": "^3.0.2",
     "@pixi/graphics": "^7.4.3",

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,5 +1,5 @@
-import { Component, computed, inject, ViewChild } from '@angular/core';
-import type { OnInit } from '@angular/core';
+import { Component, computed, inject, viewChild } from '@angular/core';
+import type { OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { TippyDirective } from '@ngneat/helipopper';
 import { SweetAlert2Module } from '@sweetalert2/ngx-sweetalert2';
@@ -21,9 +21,9 @@ import {
 } from '@helpers';
 import type { GameCurrency, Icon } from '@interfaces';
 import { MetaService } from '@services/meta.service';
+import type { SwalComponent } from '@sweetalert2/ngx-sweetalert2';
 import { IconComponent } from '@components/icon/icon.component';
 import { MarkerCurrencyCurrentComponent } from '@components/marker-currency-current/marker-currency-current.component';
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { HotkeysService } from '@ngneat/hotkeys';
 
 @Component({
@@ -40,9 +40,8 @@ import { HotkeysService } from '@ngneat/hotkeys';
   templateUrl: './navbar.component.html',
   styleUrl: './navbar.component.scss',
 })
-export class NavbarComponent implements OnInit {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  @ViewChild('leaveSwal') leaveSwal: any;
+export class NavbarComponent implements OnInit, OnDestroy {
+  public leaveSwal = viewChild<SwalComponent>('leaveSwal');
   public meta = inject(MetaService);
   public router = inject(Router);
 
@@ -155,8 +154,8 @@ export class NavbarComponent implements OnInit {
   }
 
   //KEYBOARD SHORTCUTS HERE!
-
-  constructor(private hotkeys: HotkeysService) {}
+  private hotkeys = inject(HotkeysService);
+  constructor() {}
 
   ngOnInit() {
     // Menu toggles
@@ -185,7 +184,20 @@ export class NavbarComponent implements OnInit {
 
     // Navigation
     this.hotkeys.addShortcut({ keys: 'q' }).subscribe(() => {
-      this.leaveSwal?.fire();
+      this.leaveSwal()?.fire();
     });
+  }
+  ngOnDestroy() {
+    this.hotkeys.removeShortcuts([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      'space',
+      'escape',
+      'q',
+    ]);
   }
 }

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, ViewChild } from '@angular/core';
+import type { OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { TippyDirective } from '@ngneat/helipopper';
 import { SweetAlert2Module } from '@sweetalert2/ngx-sweetalert2';
@@ -22,6 +23,8 @@ import type { GameCurrency, Icon } from '@interfaces';
 import { MetaService } from '@services/meta.service';
 import { IconComponent } from '@components/icon/icon.component';
 import { MarkerCurrencyCurrentComponent } from '@components/marker-currency-current/marker-currency-current.component';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { HotkeysService } from '@ngneat/hotkeys';
 
 @Component({
   selector: 'app-navbar',
@@ -37,7 +40,9 @@ import { MarkerCurrencyCurrentComponent } from '@components/marker-currency-curr
   templateUrl: './navbar.component.html',
   styleUrl: './navbar.component.scss',
 })
-export class NavbarComponent {
+export class NavbarComponent implements OnInit {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  @ViewChild('leaveSwal') leaveSwal: any;
   public meta = inject(MetaService);
   public router = inject(Router);
 
@@ -147,5 +152,40 @@ export class NavbarComponent {
 
   public togglePause() {
     setOption('gameloopPaused', !this.isPaused());
+  }
+
+  //KEYBOARD SHORTCUTS HERE!
+
+  constructor(private hotkeys: HotkeysService) {}
+
+  ngOnInit() {
+    // Menu toggles
+    this.hotkeys.addShortcut({ keys: '1' }).subscribe(() => this.toggleTown());
+    this.hotkeys
+      .addShortcut({ keys: '2' })
+      .subscribe(() => this.toggleCombat());
+    this.hotkeys
+      .addShortcut({ keys: '3' })
+      .subscribe(() => this.toggleInventory());
+    this.hotkeys
+      .addShortcut({ keys: '4' })
+      .subscribe(() => this.toggleHeroes());
+    this.hotkeys
+      .addShortcut({ keys: '6' })
+      .subscribe(() => this.toggleOptions());
+
+    // Game controls
+    this.hotkeys.addShortcut({ keys: '5' }).subscribe(() => this.focusCamera());
+    this.hotkeys
+      .addShortcut({ keys: 'space' })
+      .subscribe(() => this.togglePause());
+    this.hotkeys
+      .addShortcut({ keys: 'escape' })
+      .subscribe(() => closeAllMenus());
+
+    // Navigation
+    this.hotkeys.addShortcut({ keys: 'q' }).subscribe(() => {
+      this.leaveSwal?.fire();
+    });
   }
 }

--- a/src/app/pages/game-play/game-play.component.ts
+++ b/src/app/pages/game-play/game-play.component.ts
@@ -1,5 +1,4 @@
 import { DecimalPipe } from '@angular/common';
-import type { OnInit } from '@angular/core';
 import { Component, computed } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { GameMapPixiComponent } from '@components/game-map-pixi/game-map-pixi.component';
@@ -9,17 +8,11 @@ import { PanelInventoryComponent } from '@components/panel-inventory/panel-inven
 import { PanelLocationComponent } from '@components/panel-location/panel-location.component';
 import { PanelOptionsComponent } from '@components/panel-options/panel-options.component';
 import { PanelTownComponent } from '@components/panel-town/panel-town.component';
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { HotkeysService } from '@ngneat/hotkeys';
 
 import {
-  closeAllMenus,
   dismissWinGameDialog,
-  focusCameraOnPlayer,
   gamestate,
-  getOption,
   isCatchingUp,
-  setOption,
   showCombatMenu,
   showHeroesMenu,
   showInventoryMenu,
@@ -44,14 +37,13 @@ import {
   templateUrl: './game-play.component.html',
   styleUrl: './game-play.component.scss',
 })
-export class GamePlayComponent implements OnInit {
+export class GamePlayComponent {
   public showOptions = computed(() => showOptionsMenu());
   public showHeroes = computed(() => showHeroesMenu());
   public showCombat = computed(() => showCombatMenu());
   public showLocation = computed(() => showLocationMenu());
   public showInventory = computed(() => showInventoryMenu());
   public showTown = computed(() => showTownMenu());
-  private isGameloopPaused = computed(() => getOption('gameloopPaused'));
   public isCatchingUp = computed(() => isCatchingUp());
   public showWinNotification = computed(
     () =>
@@ -61,76 +53,5 @@ export class GamePlayComponent implements OnInit {
 
   continuePlayingPostWin() {
     dismissWinGameDialog();
-  }
-
-  constructor(private hotkeys: HotkeysService) {}
-
-  ngOnInit() {
-    //Space to pause and resume
-    this.hotkeys
-      .addShortcut({ keys: 'space' })
-      .subscribe(() => setOption('gameloopPaused', !this.isGameloopPaused()));
-
-    //Escape to close open menu
-    this.hotkeys
-      .addShortcut({ keys: 'escape' })
-      .subscribe(() => closeAllMenus());
-
-    //1 to show Town menu
-    this.hotkeys.addShortcut({ keys: '1' }).subscribe(() => {
-      if (showTownMenu()) {
-        showTownMenu.set(false);
-        return;
-      }
-
-      closeAllMenus();
-      showTownMenu.set(!showTownMenu());
-    });
-
-    //2 to show Combat menu
-    this.hotkeys.addShortcut({ keys: '2' }).subscribe(() => {
-      if (showCombatMenu()) {
-        showCombatMenu.set(false);
-        return;
-      }
-
-      closeAllMenus();
-      showCombatMenu.set(!showCombatMenu());
-    });
-
-    //3 to show Inventory menu
-    this.hotkeys.addShortcut({ keys: '3' }).subscribe(() => {
-      if (showInventoryMenu()) {
-        showInventoryMenu.set(false);
-        return;
-      }
-      closeAllMenus();
-      showInventoryMenu.set(!showInventoryMenu());
-    });
-
-    //4 to show Hero menu
-    this.hotkeys.addShortcut({ keys: '4' }).subscribe(() => {
-      if (showHeroesMenu()) {
-        showHeroesMenu.set(false);
-        return;
-      }
-
-      closeAllMenus();
-      showHeroesMenu.set(!showHeroesMenu());
-    });
-    //5 to show player location
-    this.hotkeys.addShortcut({ keys: '5' }).subscribe(() => {
-      focusCameraOnPlayer();
-    });
-    //6 to show Options
-    this.hotkeys.addShortcut({ keys: '6' }).subscribe(() => {
-      if (showOptionsMenu()) {
-        showOptionsMenu.set(false);
-        return;
-      }
-
-      closeAllMenus();
-      showOptionsMenu.set(!showOptionsMenu());
-    });
   }
 }

--- a/src/app/pages/game-play/game-play.component.ts
+++ b/src/app/pages/game-play/game-play.component.ts
@@ -1,5 +1,6 @@
 import { DecimalPipe } from '@angular/common';
-import { Component, computed, HostListener } from '@angular/core';
+import type { OnInit } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { GameMapPixiComponent } from '@components/game-map-pixi/game-map-pixi.component';
 import { PanelCombatComponent } from '@components/panel-combat/panel-combat.component';
@@ -8,10 +9,13 @@ import { PanelInventoryComponent } from '@components/panel-inventory/panel-inven
 import { PanelLocationComponent } from '@components/panel-location/panel-location.component';
 import { PanelOptionsComponent } from '@components/panel-options/panel-options.component';
 import { PanelTownComponent } from '@components/panel-town/panel-town.component';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import { HotkeysService } from '@ngneat/hotkeys';
 
 import {
   closeAllMenus,
   dismissWinGameDialog,
+  focusCameraOnPlayer,
   gamestate,
   getOption,
   isCatchingUp,
@@ -40,7 +44,7 @@ import {
   templateUrl: './game-play.component.html',
   styleUrl: './game-play.component.scss',
 })
-export class GamePlayComponent {
+export class GamePlayComponent implements OnInit {
   public showOptions = computed(() => showOptionsMenu());
   public showHeroes = computed(() => showHeroesMenu());
   public showCombat = computed(() => showCombatMenu());
@@ -55,21 +59,78 @@ export class GamePlayComponent {
   );
   public winTicks = computed(() => gamestate().meta.wonAtTick);
 
-  @HostListener('document:keydown.escape', ['$event'])
-  onEscapeKey(event: KeyboardEvent) {
-    closeAllMenus();
-    event.preventDefault();
-    event.stopPropagation();
-  }
-
-  @HostListener('document:keydown.space', ['$event'])
-  onSpaceKey(event: KeyboardEvent) {
-    setOption('gameloopPaused', !this.isGameloopPaused());
-    event.preventDefault();
-    event.stopPropagation();
-  }
-
   continuePlayingPostWin() {
     dismissWinGameDialog();
+  }
+
+  constructor(private hotkeys: HotkeysService) {}
+
+  ngOnInit() {
+    //Space to pause and resume
+    this.hotkeys
+      .addShortcut({ keys: 'space' })
+      .subscribe(() => setOption('gameloopPaused', !this.isGameloopPaused()));
+
+    //Escape to close open menu
+    this.hotkeys
+      .addShortcut({ keys: 'escape' })
+      .subscribe(() => closeAllMenus());
+
+    //1 to show Town menu
+    this.hotkeys.addShortcut({ keys: '1' }).subscribe(() => {
+      if (showTownMenu()) {
+        showTownMenu.set(false);
+        return;
+      }
+
+      closeAllMenus();
+      showTownMenu.set(!showTownMenu());
+    });
+
+    //2 to show Combat menu
+    this.hotkeys.addShortcut({ keys: '2' }).subscribe(() => {
+      if (showCombatMenu()) {
+        showCombatMenu.set(false);
+        return;
+      }
+
+      closeAllMenus();
+      showCombatMenu.set(!showCombatMenu());
+    });
+
+    //3 to show Inventory menu
+    this.hotkeys.addShortcut({ keys: '3' }).subscribe(() => {
+      if (showInventoryMenu()) {
+        showInventoryMenu.set(false);
+        return;
+      }
+      closeAllMenus();
+      showInventoryMenu.set(!showInventoryMenu());
+    });
+
+    //4 to show Hero menu
+    this.hotkeys.addShortcut({ keys: '4' }).subscribe(() => {
+      if (showHeroesMenu()) {
+        showHeroesMenu.set(false);
+        return;
+      }
+
+      closeAllMenus();
+      showHeroesMenu.set(!showHeroesMenu());
+    });
+    //5 to show player location
+    this.hotkeys.addShortcut({ keys: '5' }).subscribe(() => {
+      focusCameraOnPlayer();
+    });
+    //6 to show Options
+    this.hotkeys.addShortcut({ keys: '6' }).subscribe(() => {
+      if (showOptionsMenu()) {
+        showOptionsMenu.set(false);
+        return;
+      }
+
+      closeAllMenus();
+      showOptionsMenu.set(!showOptionsMenu());
+    });
   }
 }


### PR DESCRIPTION
# Description
feat: implement hotkey system using @ngneat/hotkeys

## Summary of Changes

- Install @ngneat/hotkeys package for centralized hotkey management
- Refactor game-play.component.ts to use lifecycle-based hotkey setup:
  - Import OnInit interface as type-only import
  - Import HotkeysService with ESLint disable (DI requirement vs type-only conflict)
  - Implement OnInit interface and move hotkey logic to ngOnInit()
  - Remove @HostListener decorators in favor of centralized hotkey service

Add hotkey mappings:
- 1: Toggle town menu
- 2: Toggle combat menu
- 3: Toggle inventory menu
- 4: Toggle heroes menu
- 5: Focus camera on player
- 6: Toggle options menu
- Space: Pause/resume game (feature already exist, changed method to new ng)
- Escape: Close all menus (feature already exist, changed method to new ng)

TODO: Add logout hotkey (q key)

Fixes #73 

[Feature] Migrate hotkey uses to ngneat/hotkeys

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [Y] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [Y] I have performed a self-review of my own code
- [Y] I have made corresponding changes to the documentation
- [Y] My changes generate no new warnings
- [Y] I have run tests (npm run test) that prove my fix is effective or that my feature works
