### PR TITLE
[Feature] Speed should affect exploration #172

### DIFF
--- a/src/app/helpers/travel.ts
+++ b/src/app/helpers/travel.ts
@@ -3,6 +3,8 @@ import { notify } from '@helpers/notify';
 import { gamestate, updateGamestate } from '@helpers/state-game';
 import { locationTraitExplorationMultiplier } from '@helpers/trait-location-exploration';
 import type { Hero, WorldLocation, WorldPosition } from '@interfaces';
+import { allHeroes } from '@helpers/hero';
+import { meanBy } from 'es-toolkit/compat';
 
 export function isTraveling() {
   return gamestate().hero.travel.ticksLeft > 0;
@@ -32,21 +34,16 @@ export function travelTimeFromCurrentLocationTo(node: WorldLocation): number {
     baseTravelTime * travelTimeMultiplier,
   );
 
-  const heroSpeeds: number[] = [];
+  const averageHeroSpeed = meanBy(
+    allHeroes(),
+    (heroSpeed) => heroSpeed.totalStats.Speed,
+  );
 
-  gamestate().hero.heroes.forEach((thisHero: Hero) => {
-    heroSpeeds.push(thisHero.totalStats.Speed);
-  });
-
-  const averageHeroSpeed =
-    heroSpeeds.reduce((totalSpeed, speed) => totalSpeed + speed, 0) /
-    heroSpeeds.length;
-
-  const heroSpeedTravelTimeReductionVar = 1 + averageHeroSpeed / 100;
+  const tickReduction = averageHeroSpeed;
 
   const totalTravelTime = baseTravelTime + travelTimeModification;
 
-  return Math.round(totalTravelTime / heroSpeedTravelTimeReductionVar);
+  return Math.max(1, totalTravelTime - tickReduction);
 }
 
 export function travelToNode(node: WorldLocation): void {

--- a/src/app/helpers/travel.ts
+++ b/src/app/helpers/travel.ts
@@ -2,7 +2,7 @@ import { getFestivalExplorationTickMultiplier } from '@helpers/festival-explorat
 import { notify } from '@helpers/notify';
 import { gamestate, updateGamestate } from '@helpers/state-game';
 import { locationTraitExplorationMultiplier } from '@helpers/trait-location-exploration';
-import type { Hero, WorldLocation, WorldPosition } from '@interfaces';
+import type { WorldLocation, WorldPosition } from '@interfaces';
 import { allHeroes } from '@helpers/hero';
 import { meanBy } from 'es-toolkit/compat';
 

--- a/src/app/helpers/travel.ts
+++ b/src/app/helpers/travel.ts
@@ -2,7 +2,7 @@ import { getFestivalExplorationTickMultiplier } from '@helpers/festival-explorat
 import { notify } from '@helpers/notify';
 import { gamestate, updateGamestate } from '@helpers/state-game';
 import { locationTraitExplorationMultiplier } from '@helpers/trait-location-exploration';
-import type { WorldLocation, WorldPosition } from '@interfaces';
+import type { Hero, WorldLocation, WorldPosition } from '@interfaces';
 
 export function isTraveling() {
   return gamestate().hero.travel.ticksLeft > 0;
@@ -31,9 +31,22 @@ export function travelTimeFromCurrentLocationTo(node: WorldLocation): number {
   const travelTimeModification = Math.floor(
     baseTravelTime * travelTimeMultiplier,
   );
+
+  const heroSpeeds: number[] = [];
+
+  gamestate().hero.heroes.forEach((thisHero: Hero) => {
+    heroSpeeds.push(thisHero.totalStats.Speed);
+  });
+
+  const averageHeroSpeed =
+    heroSpeeds.reduce((totalSpeed, speed) => totalSpeed + speed, 0) /
+    heroSpeeds.length;
+
+  const heroSpeedTravelTimeReductionVar = 1 + averageHeroSpeed / 100;
+
   const totalTravelTime = baseTravelTime + travelTimeModification;
 
-  return totalTravelTime;
+  return Math.round(totalTravelTime / heroSpeedTravelTimeReductionVar);
 }
 
 export function travelToNode(node: WorldLocation): void {


### PR DESCRIPTION
# Description
Reduce travel time based on hero average speed

## Summary of Changes

- modified travelTimeFromCurrentLocationTo() return type to reduce depending on the average hero speed
- returned travel time is reduced as a percentage of the average hero speed: ie average hero speed of 5 => 5% reduction Math.round() used.

Files changed:
- travel.ts

If your PR summary is AI-generated, it will be closed.

Fixes #172 

## Screenshot

Screenshot shows a few scenarios of the change with:

Distance between nodes
Average Hero speed
returned travel distance before reduction
returned travel distance after reduction

<img width="1197" height="1022" alt="image" src="https://github.com/user-attachments/assets/66311794-9d98-407d-bb6b-1e7e5ea0f8f0" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have run tests (npm run test) that prove my fix is effective or that my feature works
